### PR TITLE
Avoid setting System properties as empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Using maven, include it as a dependency:
 <dependency>
   <groupId>io.ddavison</groupId>
   <artifactId>conductor</artifactId>
-  <version>2.0.1</version>
+  <version>2.0.2</version>
 </dependency>
 ```
 

--- a/src/main/java/io/ddavison/conductor/Locomotive.java
+++ b/src/main/java/io/ddavison/conductor/Locomotive.java
@@ -209,17 +209,14 @@ public class Locomotive implements Conductor<Locomotive> {
         // Set the webdriver env vars.
         if (getJvmProperty("os.name").toLowerCase().contains("mac")) {
             System.setProperty("webdriver.chrome.driver", findFile("chromedriver.mac"));
-            System.setProperty("webdriver.firefox.driver", "");
         } else if (getJvmProperty("os.name").toLowerCase().contains("nix") ||
                    getJvmProperty("os.name").toLowerCase().contains("nux") ||
                    getJvmProperty("os.name").toLowerCase().contains("aix")
         ) {
             System.setProperty("webdriver.chrome.driver", findFile("chromedriver.linux"));
-            System.setProperty("webdriver.firefox.driver", "");
         } else if (getJvmProperty("os.name").toLowerCase().contains("win")) {
             System.setProperty("webdriver.chrome.driver", findFile("chromedriver.exe"));
             System.setProperty("webdriver.ie.driver", findFile("iedriver.exe"));
-            System.setProperty("webdriver.firefox.driver", "");
         } else {
 
         }


### PR DESCRIPTION
This pull request has the following changes:
- calls to System.setProperty("webdriver.firefox.driver", "") are removed because it tricks NewProfileExtensionConnection:178 from Selenium into thinking that user is trying to load a custom extension, because the result of System.getProperty(FIREFOX_DRIVER_XPI_PROPERTY) is an empty string "", which is not null and so the condition is resolved to true. This ends with an error since it cannot find the file with the path ""

- updated the version in the README file to reflect the newest artifact available in Maven Central