### PR TITLE
Move to PhantomJS fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 
   <properties>
     <selenium_version>2.52.0</selenium_version>
-    <phantomjs_version>1.2.0</phantomjs_version>
+    <phantomjs_version>1.2.1</phantomjs_version>
     <CONDUCTOR_URL>${env.CONDUCTOR_URL}</CONDUCTOR_URL>
     <CONDUCTOR_BROWSER>${env.CONDUCTOR_BROWSER}</CONDUCTOR_BROWSER>
     <CONDUCTOR_HUB>${env.CONDUCTOR_HUB}</CONDUCTOR_HUB>
@@ -122,7 +122,7 @@
       <version>4.10</version>
     </dependency>
     <dependency>
-      <groupId>com.github.detro</groupId>
+      <groupId>com.codeborne</groupId>
       <artifactId>phantomjsdriver</artifactId>
       <version>${phantomjs_version}</version>
     </dependency>


### PR DESCRIPTION
Someone on [reddit](https://www.reddit.com/r/selenium/comments/5ooxap/how_to_setup_selenium_with_the_java_conductor/) posted they were struggling to get this library working with PhantomJS.  I've offered them advice, but thought I would also raise a patch with fixes the issue for future users.